### PR TITLE
PSASSET-274: adding chefspec coverage to default.

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+repo_token: vOqgwhRIywLKpCuqPihggjImUrHoUljRr

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :integration do
   gem 'kitchen-vagrant', '0.15.0'
   gem 'strainer', '~> 3.3.0'
   gem 'rspec-expectations', '~> 2.14.0'
+  gem 'coveralls', require: false
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,59 @@
+require_relative 'spec_helper'
+
+describe 'rs-haproxy::default' do
+
+  context 'main haproxy without ssl' do
+    let(:chef_run) do
+      ChefSpec::Runner.new do |node|
+      end.converge(described_recipe)
+    end
+
+    it 'includes rs-base::rsyslog' do
+      expect(chef_run).to include_recipe('rs-base::rsyslog')
+    end
+
+    it 'creates rsyslog configuration' do
+      expect(chef_run).to create_cookbook_file('/etc/rsyslog.d/10-haproxy.conf').with(
+          source: 'rsyslog-10-haproxy.conf',
+          backup: 0,
+          mode: 0644,
+          owner: 'root',
+          group: 'root'
+      )
+    end
+
+    it 'creates logrotate file' do
+      expect(chef_run).to create_cookbook_file('/etc/logrotate.d/logrotate').with(
+          source: 'logrotate-haproxy.conf',
+          backup: 0,
+          mode: 0644,
+          owner: 'root',
+          group: 'root'
+      )
+    end
+
+  end
+
+  context 'ssl is enabled' do
+    let(:chef_run) do
+      ChefSpec::Runner.new do |node|
+        node.set['rs-haproxy']['ssl_cert'] = 'certdata'
+      end.converge(described_recipe)
+    end
+    let (:haproxy_conf_dir) { ::File.join(chef_run.node['haproxy']['source']['prefix'], chef_run.node['haproxy']['conf_dir']) }
+    let (:ssl_cert_file) { ::File.join(haproxy_conf_dir, 'ssl_cert.pem') }
+
+    it 'creates cert dir' do
+      expect(chef_run).to create_directory(haproxy_conf_dir)
+    end
+
+    it 'creates cert file' do
+      expect(chef_run).to create_file(ssl_cert_file).with(
+        content: chef_run.node['rs-haproxy']['ssl_cert'],
+        mode: 0600
+      )
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ $LOAD_PATH.unshift(libraries_path) unless $LOAD_PATH.include?(libraries_path)
 
 require 'chefspec'
 require 'chefspec/berkshelf'
+ChefSpec::Coverage.start!
 
 RSpec.configure do |config|
   config.platform = 'ubuntu'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ $LOAD_PATH.unshift(libraries_path) unless $LOAD_PATH.include?(libraries_path)
 
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'coveralls'
+Coveralls.wear!
+
 ChefSpec::Coverage.start!
 
 RSpec.configure do |config|


### PR DESCRIPTION
ChefSpec Coverage report generated...

  Total Resources:   9
  Touched Resources: 8
  Touch Coverage:    88.89%
Untouched Resources:

  haproxy[set up haproxy.cnf]        rs-haproxy/recipes/default.rb:17

Not Matchers Upstream to test against
